### PR TITLE
Clean URLs with Year Disambiguation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,8 +29,11 @@ const App = () => {
           <Routes>
             <Route path="/" element={<HomePage />} />
             {/* <Route path="/" element={<MovieSearch />} /> */}
-            <Route path="/movie/:movieId" element={<MovieDetails />} />
-            <Route path="/actor/:actorId" element={<ActorFilmography />} />
+            <Route path="/movie/:movieIdentifier" element={<MovieDetails />} />
+            <Route
+              path="/actor/:actorIdentifier"
+              element={<ActorFilmography />}
+            />
           </Routes>
         </main>
       </Router>

--- a/src/components/ActorCard/ActorCard.tsx
+++ b/src/components/ActorCard/ActorCard.tsx
@@ -7,6 +7,7 @@ import { ActorHeader } from "./components/ActorHeader";
 import { ActorMetrics } from "./components/ActorMetrics";
 import classNames from "classnames";
 import { trackActorEvent, trackNavigationEvent } from "../../utils/posthog";
+import { createActorSlug } from "../../utils/slugUtils";
 
 const ActorCard: React.FC<ActorCardProps> = ({
   actor,
@@ -29,7 +30,8 @@ const ActorCard: React.FC<ActorCardProps> = ({
   );
 
   const handleCardClick = () => {
-    console.log("Card clicked, navigating to:", `/actor/${actor.id}`);
+    const actorSlug = createActorSlug(actor.name);
+    console.log("Card clicked, navigating to:", `/actor/${actorSlug}`);
 
     // Track actor card click with PostHog
     trackActorEvent("actor_card_clicked", {
@@ -43,10 +45,10 @@ const ActorCard: React.FC<ActorCardProps> = ({
 
     // Track navigation event
     const currentPage = window.location.pathname;
-    const targetPage = `/actor/${actor.id}`;
+    const targetPage = `/actor/${actorSlug}`;
     trackNavigationEvent(currentPage, targetPage);
 
-    navigate(`/actor/${actor.id}`);
+    navigate(`/actor/${actorSlug}`);
   };
 
   return (

--- a/src/components/ActorFilmography/ActorFilmography.tsx
+++ b/src/components/ActorFilmography/ActorFilmography.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { fetchActorFilmography, fetchActorDetails } from "../../utils/api";
+import {
+  fetchActorFilmography,
+  fetchActorDetails,
+  fetchActorByName,
+} from "../../utils/api";
 import { Movie, Actor } from "../../types/types";
 import styles from "./ActorFilmography.module.css";
+import { parseActorIdentifier, createMovieSlug } from "../../utils/slugUtils";
 import {
   logComponentRender,
   logUserAction,
@@ -19,8 +24,8 @@ import {
  * - Navigation links to individual movie pages
  */
 const ActorFilmography: React.FC = () => {
-  // Extract actor ID from URL parameters (e.g., /actor/123)
-  const { actorId } = useParams<{ actorId: string }>();
+  // Extract actor identifier from URL parameters (e.g., /actor/123 or /actor/actor-name-123)
+  const { actorIdentifier } = useParams<{ actorIdentifier: string }>();
 
   // State management for component data
   const [filmography, setFilmography] = useState<Movie[]>([]); // Array of movies the actor appeared in
@@ -40,34 +45,47 @@ const ActorFilmography: React.FC = () => {
 
   /**
    * Main data fetching effect
-   * Runs when actorId changes (component mounts or URL changes)
+   * Runs when actorIdentifier changes (component mounts or URL changes)
    */
   useEffect(() => {
     const getActorData = async () => {
-      if (actorId) {
-        const startTime = performance.now();
+      if (actorIdentifier) {
+        const parsed = parseActorIdentifier(actorIdentifier);
+        if (parsed) {
+          const startTime = performance.now();
 
-        // Fetch actor's personal details (name, profile image, etc.)
-        const actorDetails = (await fetchActorDetails(
-          Number(actorId)
-        )) as Actor;
-        setActor(actorDetails);
+          let actorDetails: Actor | null = null;
 
-        // Fetch actor's complete filmography
-        let filmographyData = await fetchActorFilmography(Number(actorId));
+          if (parsed.id) {
+            // Numeric ID - fetch by ID
+            actorDetails = (await fetchActorDetails(parsed.id)) as Actor;
+          } else if (parsed.name) {
+            // Slug - fetch by name
+            actorDetails = await fetchActorByName(
+              parsed.name.replace(/-/g, " ")
+            );
+          }
 
-        // Sort filmography by release date (newest first)
-        // This creates a chronological timeline from most recent to oldest
-        filmographyData = filmographyData.sort(
-          (a, b) =>
-            new Date(b.release_date).getTime() -
-            new Date(a.release_date).getTime()
-        );
-        setFilmography(filmographyData);
+          if (actorDetails) {
+            setActor(actorDetails);
+
+            // Fetch actor's complete filmography
+            let filmographyData = await fetchActorFilmography(actorDetails.id);
+
+            // Sort filmography by release date (newest first)
+            // This creates a chronological timeline from most recent to oldest
+            filmographyData = filmographyData.sort(
+              (a, b) =>
+                new Date(b.release_date).getTime() -
+                new Date(a.release_date).getTime()
+            );
+            setFilmography(filmographyData);
+          }
+        }
       }
     };
     getActorData();
-  }, [actorId]);
+  }, [actorIdentifier]);
 
   // Loading states - show appropriate messages while data is being fetched
   if (!actor) return <p>Loading actor data...</p>;
@@ -129,7 +147,10 @@ const ActorFilmography: React.FC = () => {
         {filmography.map((movie) => (
           <li key={movie.id} className={styles.filmographyItem}>
             {/* Each movie is a clickable link to its details page */}
-            <Link to={`/movie/${movie.id}`} className={styles.movieLink}>
+            <Link
+              to={`/movie/${createMovieSlug(movie.title, movie.release_date)}`}
+              className={styles.movieLink}
+            >
               {/* Movie poster image */}
               <div className={styles.filmographyItemContent}>
                 <img

--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { fetchMovieById, fetchMovieCast } from "../../utils/api";
+import {
+  fetchMovieById,
+  fetchMovieByTitle,
+  fetchMovieCast,
+} from "../../utils/api";
 import { Movie, Actor } from "../../types/types";
 import styles from "./MovieDetails.module.css";
 import ActorCard from "../ActorCard/ActorCard.tsx";
 import Select from "../Select/Select";
 import SettingsMenu from "../SettingsMenu/SettingsMenu";
 import StatusTag from "../StatusTag/StatusTag";
+import { parseMovieIdentifier } from "../../utils/slugUtils";
 import {
   logComponentRender,
   logUserAction,
@@ -14,7 +19,7 @@ import {
 } from "../../utils/sentry";
 
 const MovieDetails: React.FC = () => {
-  const { movieId } = useParams<{ movieId: string }>();
+  const { movieIdentifier } = useParams<{ movieIdentifier: string }>();
   const [movie, setMovie] = useState<Movie | null>(null);
   const [cast, setCast] = useState<Actor[]>([]);
   const [statusFilter, setStatusFilter] = useState("All");
@@ -25,25 +30,37 @@ const MovieDetails: React.FC = () => {
 
   useEffect(() => {
     const getMovieDetails = async () => {
-      if (movieId) {
-        const startTime = performance.now();
+      if (movieIdentifier) {
+        const parsed = parseMovieIdentifier(movieIdentifier);
+        if (parsed) {
+          const startTime = performance.now();
 
-        const movieData = await fetchMovieById(Number(movieId));
-        setMovie(movieData);
+          let movieData: Movie | null = null;
 
-        if (movieData?.release_date) {
-          setLoadingCast(true);
-          const castData = await fetchMovieCast(
-            Number(movieId),
-            movieData.release_date
-          );
-          setCast(castData);
-          setLoadingCast(false);
+          if (parsed.id) {
+            // Numeric ID - fetch by ID
+            movieData = await fetchMovieById(parsed.id);
+          } else if (parsed.title) {
+            // Slug - fetch by title and year
+            movieData = await fetchMovieByTitle(parsed.title, parsed.year);
+          }
+
+          setMovie(movieData);
+
+          if (movieData?.id && movieData?.release_date) {
+            setLoadingCast(true);
+            const castData = await fetchMovieCast(
+              movieData.id,
+              movieData.release_date
+            );
+            setCast(castData);
+            setLoadingCast(false);
+          }
         }
       }
     };
     getMovieDetails();
-  }, [movieId]);
+  }, [movieIdentifier]);
 
   if (!movie) return <p>Loading movie details...</p>;
 

--- a/src/components/MovieItem/MovieItem.tsx
+++ b/src/components/MovieItem/MovieItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Movie } from "../../types/types";
+import { createMovieSlug } from "../../utils/slugUtils";
 
 import styles from "./MovieItem.module.css";
 interface MovieItemProps {
@@ -11,7 +12,7 @@ const MovieItem: React.FC<MovieItemProps> = ({ movie }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/movie/${movie.id}`);
+    navigate(`/movie/${createMovieSlug(movie.title, movie.release_date)}`);
   };
 
   return (

--- a/src/components/MovieSearch/MovieSearch.tsx
+++ b/src/components/MovieSearch/MovieSearch.tsx
@@ -14,6 +14,7 @@ import {
   logComponentRender,
 } from "../../utils/sentry";
 import { trackSearchEvent, trackNavigationEvent } from "../../utils/posthog";
+import { createMovieSlug, createActorSlug } from "../../utils/slugUtils";
 
 // ============================================================================
 // TYPE DEFINITIONS
@@ -272,10 +273,12 @@ const MovieSearch: React.FC<MovieSearchProps> = ({
 
   // Handle clicking on a suggestion item
   const handleSuggestionClick = (item: Suggestion) => {
-    const currentPage = window.location.pathname;
-    const targetPage =
-      item.type === "movie" ? `/movie/${item.id}` : `/actor/${item.id}`;
     const itemTitle = item.type === "movie" ? item.title : item.name;
+    const targetPage =
+      item.type === "movie"
+        ? `/movie/${createMovieSlug(item.title, item.release_date)}`
+        : `/actor/${createActorSlug(item.name)}`;
+    const currentPage = window.location.pathname;
 
     // Log selection for analytics
     addBreadcrumb("selection", "User clicked suggestion", "info", {
@@ -301,9 +304,9 @@ const MovieSearch: React.FC<MovieSearchProps> = ({
 
     // Navigate to appropriate detail page
     if (item.type === "movie") {
-      navigate(`/movie/${item.id}`);
+      navigate(`/movie/${createMovieSlug(item.title, item.release_date)}`);
     } else {
-      navigate(`/actor/${item.id}`);
+      navigate(`/actor/${createActorSlug(item.name)}`);
     }
   };
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -229,10 +229,81 @@ const fetchActorFilmography = async (actorId: number): Promise<Movie[]> => {
   }
 };
 
+/**
+ * Fetches a movie by its title and optionally year (for slug-based URLs)
+ * @param title - The movie title
+ * @param year - Optional release year for disambiguation
+ * @returns The movie information or null if not found
+ */
+const fetchMovieByTitle = async (
+  title: string,
+  year?: number
+): Promise<Movie | null> => {
+  try {
+    // Search for the movie by title
+    const movies = await fetchMovies(title);
+
+    let exactMatch: Movie | undefined;
+
+    if (year) {
+      // If year is provided, find exact match by title and year
+      exactMatch = movies.find(
+        (movie) =>
+          movie.title.toLowerCase() === title.toLowerCase() &&
+          new Date(movie.release_date).getFullYear() === year
+      );
+    } else {
+      // If no year, find exact match by title only
+      exactMatch = movies.find(
+        (movie) => movie.title.toLowerCase() === title.toLowerCase()
+      );
+    }
+
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    // If no exact match, return the first result
+    return movies.length > 0 ? movies[0] : null;
+  } catch (error) {
+    console.error("Error fetching movie by title:", error);
+    return null;
+  }
+};
+
+/**
+ * Fetches an actor by their name (for slug-based URLs)
+ * @param name - The actor name
+ * @returns The actor information or null if not found
+ */
+const fetchActorByName = async (name: string): Promise<Actor | null> => {
+  try {
+    // Search for the actor by name
+    const actors = await fetchActors(name);
+
+    // Find exact match (case-insensitive)
+    const exactMatch = actors.find(
+      (actor) => actor.name.toLowerCase() === name.toLowerCase()
+    );
+
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    // If no exact match, return the first result
+    return actors.length > 0 ? actors[0] : null;
+  } catch (error) {
+    console.error("Error fetching actor by name:", error);
+    return null;
+  }
+};
+
 export {
   fetchActorDetails,
   fetchActorFilmography,
   fetchMovieById,
+  fetchMovieByTitle,
+  fetchActorByName,
   fetchSuggestions,
   fetchMovieCast,
   fetchMovies,

--- a/src/utils/slugUtils.ts
+++ b/src/utils/slugUtils.ts
@@ -1,0 +1,141 @@
+/**
+ * Utility functions for creating URL-friendly slugs from movie titles and actor names
+ * and parsing them back to extract IDs.
+ */
+
+/**
+ * Creates a URL-friendly slug from a string (movie title or actor name)
+ * @param text - The text to convert to a slug
+ * @param year - Optional year for disambiguation (movies only)
+ * @param id - The ID (optional, for backward compatibility)
+ * @returns A URL-friendly slug
+ */
+export const createSlug = (
+  text: string,
+  year?: number,
+  id?: number
+): string => {
+  const baseSlug = text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "") // Remove special characters except spaces and hyphens
+    .replace(/\s+/g, "-") // Replace spaces with hyphens
+    .replace(/-+/g, "-") // Replace multiple hyphens with single hyphen
+    .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
+
+  // Add year for disambiguation if provided
+  if (year) {
+    return `${baseSlug}-${year}`;
+  }
+
+  // Only append ID if provided (for backward compatibility)
+  return id ? `${baseSlug}-${id}` : baseSlug;
+};
+
+/**
+ * Extracts the ID from a slug
+ * @param slug - The slug containing the ID
+ * @returns The extracted ID or null if not found
+ */
+export const extractIdFromSlug = (slug: string): number | null => {
+  const match = slug.match(/-(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+};
+
+/**
+ * Creates a movie URL slug with year disambiguation
+ * @param title - The movie title
+ * @param releaseDate - The movie release date (YYYY-MM-DD format)
+ * @returns A URL-friendly movie slug with year
+ */
+export const createMovieSlug = (
+  title: string,
+  releaseDate?: string
+): string => {
+  const year = releaseDate ? new Date(releaseDate).getFullYear() : undefined;
+  return createSlug(title, year);
+};
+
+/**
+ * Creates an actor URL slug (without ID for cleaner URLs)
+ * @param name - The actor name
+ * @returns A URL-friendly actor slug
+ */
+export const createActorSlug = (name: string): string => {
+  return createSlug(name);
+};
+
+/**
+ * Parses a movie slug to extract the movie title and year
+ * @param movieSlug - The movie slug from the URL
+ * @returns Object with title and optional year, or null if not found
+ */
+export const parseMovieSlug = (
+  movieSlug: string
+): { title: string; year?: number } | null => {
+  if (!movieSlug) return null;
+
+  // Check if slug ends with a 4-digit year
+  const yearMatch = movieSlug.match(/^(.+)-(\d{4})$/);
+
+  if (yearMatch) {
+    return {
+      title: yearMatch[1].replace(/-/g, " "),
+      year: parseInt(yearMatch[2], 10),
+    };
+  }
+
+  // No year found, return just the title
+  return {
+    title: movieSlug.replace(/-/g, " "),
+  };
+};
+
+/**
+ * Parses an actor slug to extract the actor name
+ * @param actorSlug - The actor slug from the URL
+ * @returns The actor name or null if not found
+ */
+export const parseActorSlug = (actorSlug: string): string | null => {
+  // For clean URLs without ID, we return the slug as the name
+  // The components will need to look up the actor by name
+  return actorSlug || null;
+};
+
+/**
+ * Checks if a string is a numeric ID (for backward compatibility)
+ * @param value - The value to check
+ * @returns True if the value is a numeric ID
+ */
+export const isNumericId = (value: string): boolean => {
+  return /^\d+$/.test(value);
+};
+
+/**
+ * Parses a movie identifier and returns either the ID or title/year
+ * @param identifier - Either a numeric ID string or a movie slug
+ * @returns Object with either id or title/year, or null if not found
+ */
+export const parseMovieIdentifier = (
+  identifier: string
+): { id?: number; title?: string; year?: number } | null => {
+  if (isNumericId(identifier)) {
+    return { id: parseInt(identifier, 10) };
+  }
+  const parsed = parseMovieSlug(identifier);
+  return parsed ? { title: parsed.title, year: parsed.year } : null;
+};
+
+/**
+ * Parses an actor identifier and returns either the ID or name
+ * @param identifier - Either a numeric ID string or an actor slug
+ * @returns Object with either id or name, or null if not found
+ */
+export const parseActorIdentifier = (
+  identifier: string
+): { id?: number; name?: string } | null => {
+  if (isNumericId(identifier)) {
+    return { id: parseInt(identifier, 10) };
+  }
+  const name = parseActorSlug(identifier);
+  return name ? { name } : null;
+};


### PR DESCRIPTION
Changes:
- Add slug utilities for URL generation/parsing with year disambiguation
- Update API to support title/name lookups
- Change routes to use :movieIdentifier and :actorIdentifier
- Update all components to generate slugs with years
Examples:
`/movie/155 → /movie/the-dark-knight-2008`
`/actor/3894 → /actor/christian-bale`

yay!